### PR TITLE
Fix caching coroutines.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Determine old tag name
         id: tag
         run: |
-          git fetch --tags
+          git fetch origin HEAD --tags --depth=2147483647
           echo 'old_tag='"$(git describe HEAD --abbrev=0 --tags)" >> $GITHUB_ENV
 
       - name: List update

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Enforce rules regarding frozen revisions in `.pre-commit-config.yaml`.
 ```yaml
 # Enforce frozen revisions in `.pre-commit-config.yaml`
 - repo: https://github.com/real-yfprojects/check-pre-commit-config
-  rev: v1.0.0-alpha1
+  rev: v1.0.0-alpha2
   hooks:
       - id: check-frozen
 ```
@@ -89,7 +89,7 @@ are passed to the underlying script when the hook is run. The following configur
 ```yaml
 # Prevent use of frozen revisions in `.pre-commit-config.yaml`
 - repo: https://github.com/real-yfprojects/check-pre-commit-config
-  rev: v1.0.0-alpha1
+  rev: v1.0.0-alpha2
   hooks:
       - id: check-frozen
         args:
@@ -103,7 +103,7 @@ If you just want to make sure that comments match revisions and that no abbrevia
 ```yaml
 # Check use of `frozen: xxx` comments in `.pre-commit-config.yaml`
 - repo: https://github.com/real-yfprojects/check-pre-commit-config
-  rev: v1.0.0-alpha1
+  rev: v1.0.0-alpha2
   hooks:
       - id: check-frozen
         args:


### PR DESCRIPTION
This fixes an error that would occur when a cached coroutine like `get_tags_in_repo` would be called multiple times with the same arguments. This bug was caused by `functools.lru_cache` not supporting coroutines.